### PR TITLE
Add formatting to the halgrep output

### DIFF
--- a/halgrep.cabal
+++ b/halgrep.cabal
@@ -1,10 +1,8 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.3.
 --
 -- see: https://github.com/sol/hpack
---
--- hash: fb5c279239e433a49282236807e530af2e5f6b50f3a9e54ca9648d2730ac5b41
 
 name:           halgrep
 version:        0.1.0.0
@@ -32,11 +30,12 @@ library
   hs-source-dirs:
       src
   build-depends:
-      base >=4.7 && <5
-    , optparse-applicative
+      ansi-terminal
+    , base >=4.7 && <5
     , bits
     , containers
     , directory
+    , optparse-applicative
     , regex-pcre
     , regex-tdfa
     , unix
@@ -50,7 +49,8 @@ executable halgrep-exe
       app
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      base >=4.7 && <5
+      ansi-terminal
+    , base >=4.7 && <5
     , bits
     , containers
     , directory
@@ -72,14 +72,15 @@ test-suite halgrep-test
       test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      base >=4.7 && <5
+      ansi-terminal
+    , base >=4.7 && <5
     , bits
     , containers
     , directory
     , halgrep
-    , optparse-applicative
     , hspec >=2.0.0
     , hspec-expectations-lifted
+    , optparse-applicative
     , regex-pcre
     , regex-tdfa
     , unix

--- a/package.yaml
+++ b/package.yaml
@@ -27,6 +27,7 @@ dependencies:
 - regex-tdfa
 - bits
 - containers
+- ansi-terminal
 
 library:
   source-dirs: src

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -5,22 +5,53 @@ module Lib
 import Options.Applicative
 import File
 import Matching
+import System.Console.ANSI
 
 someFunc :: IO ()
 someFunc = run =<< execParser appInfo
 
+-- | Represents a file match with the path of the file and the matches
+data FileMatch = FileMatch String [Match]
+
+instance Show FileMatch where
+  show (FileMatch name matches) = name ++ ":\n" ++ foldr (\x y -> ("\t" ++ show x ++ "\n") ++ y) "" matches
+
 run :: Command -> IO ()
 run (Command (Opts c fz) (Args p fs)) = do
+  putStrLn $ "Files to search: " ++ foldr (\ x y -> x ++ " " ++ y) "" fs
+  putStrLn $ "Pattern to match on: " ++ p
+  putStrLn $ "Options: Context Lines: " ++ show c ++ " fuzzy level: " ++ fz
+  putStrLn "Results: "
   files <- sequence (map File.extractFile fs)
   let patt = p
-      fileContents = map (\ (ExFile filepath contents ) -> contents) (concat files)
-      matches = map (\ x -> Matching.findMatches x 0 p) fileContents
-      matchLines = map (\ (Matching.Match m st i) -> m) (concat matches)
-  putStrLn $ "Files to search: " ++ foldr (\ x y -> x ++ " " ++ y) "" fs
-  putStrLn $ "Pattern to match on: " ++ patt
-  putStrLn $ "Options: Context Lines: " ++ show c ++ " fuzzy level: " ++ fz
-  putStrLn $ "Results: "
-  mapM_ print matchLines
+      fileMatches = filter (\(FileMatch path matches) -> not (null matches)) 
+        (map (\x -> exFileToMatch x (toFuzzy fz) patt) (concat files))
+  mapM_ printFileMatch fileMatches
+
+-- | Creates a FileMatch from the file, fuzziness of the query, and the string pattern.
+exFileToMatch :: ExFile -> Fuzziness -> String -> FileMatch
+exFileToMatch (ExFile filepath contents) fz pattern = do
+  let matches = dispatchMatching contents 0 fz pattern
+  FileMatch filepath matches
+
+-- | properly formats the console output for a FileMatch.
+printFileMatch :: FileMatch -> IO ()
+printFileMatch (FileMatch filepath matches) = do
+  setSGR [SetColor Foreground Vivid Blue]
+  putStr (filepath ++ ":\n")
+  mapM_ printMatch matches
+  putStr "\n"
+
+-- | Porperly formats the console output for a Match.
+printMatch :: Match -> IO ()
+printMatch m = do
+  let (f,s,t) = getLineParts m
+  setSGR [SetColor Foreground Vivid White]
+  putStr ("\t" ++ f)
+  setSGR [SetColor Foreground Vivid Red]
+  putStr s
+  setSGR [SetColor Foreground Vivid White]
+  putStrLn t
 
 data Opts = Opts
   { optContext :: Int
@@ -45,7 +76,6 @@ fuzzy = strOption
 
 opts :: Parser Opts
 opts = Opts <$> context <*> fuzzy
-
 
 data Args = Args
   { argPattern :: String
@@ -75,7 +105,11 @@ appInfo = info (cmd <**> helper)
   <> progDesc "Performs a search for the specified pattern in the given files."
   <> header "halgrep - a text search utility" )
 
+-- | Converts the given parameter to fuzziness level.
+toFuzzy :: [Char] -> Fuzziness
+toFuzzy "NONE" = NoFuzzy
+toFuzzy "LOW" = LowFuzzy 
+toFuzzy "MED" = MediumFuzzy 
+toFuzzy "HIGH" = HighFuzzy 
+toFuzzy err = error (err ++ " is not one of: \"NONE\", \"LOW\", \"MED\", \"HIGH\"")
 
---findMatches lines startingLineNum regex = []
---extractFile path = path
--- getFiles path = []

--- a/test/MatchingSpec.hs
+++ b/test/MatchingSpec.hs
@@ -20,7 +20,7 @@ spec = do
     -- End of test data
 
     it "should find a single match when given a single matching line" $
-      findMatches singleString 1 regexStart `shouldBe` [Match (head singleString) "This" 1]
+      findMatches singleString 1 regexStart `shouldBe` [Match (head singleString) "This" 0 1]
     
     it "should find no match when given an empty list" $
       findMatches [] 1 "" `shouldBe` []
@@ -29,16 +29,16 @@ spec = do
     it ("should find multiple matches with " ++ regexStart) $
       findMatches multipleString 10 regexStart `shouldBe` 
         [
-          Match (head multipleString) "This" 10,
-          Match (multipleString !! 3) "This" 13
+          Match (head multipleString) "This" 0 10,
+          Match (multipleString !! 3) "This" 0 13
         ]
 
     it ("should find multiple matches with " ++ regexEnd) $
       findMatches multipleString 10 regexEnd `shouldBe` 
         [
-          Match (head multipleString) "string" 10,
-          Match (multipleString !! 1) "string" 11, 
-          Match (multipleString !! 2) "string" 12
+          Match (head multipleString) "string" 19 10,
+          Match (multipleString !! 1) "string" 15 11, 
+          Match (multipleString !! 2) "string" 24 12
         ]
 
   describe "newR" $
@@ -78,7 +78,7 @@ spec = do
         Match
       -}
       let fuzzyPattern = "tridpctyla"
-      findMatchesFuzzy wildStrings 0 LowFuzzy fuzzyPattern `shouldBe` [Match (wildStrings !! 2) "tridactyla" 2]
+      findMatchesFuzzy wildStrings 0 LowFuzzy fuzzyPattern `shouldBe` [Match (wildStrings !! 2) "tridactyla" 51 2]
 
     it "should find multiple matches when a match exists" $ do
       let fuzzyPattern = "if"
@@ -90,9 +90,9 @@ spec = do
             String 3: The first occurrence is in "species", more specifically the "ie".
         -}
         [
-          Match (head wildStrings) "in" 0,
-          Match (wildStrings !! 1) "ik" 1,
-          Match (wildStrings !! 2) "ie" 2
+          Match (head wildStrings) "in" 17 0,
+          Match (wildStrings !! 1) "ik" 1 1,
+          Match (wildStrings !! 2) "ie" 11 2
         ]
 
     it "should not match with low fuzz" $ do
@@ -112,7 +112,7 @@ spec = do
         Edit: replace 'e' with 'o' => Myrmecophaga (2 edits)
         Match
       -}
-      findMatchesFuzzy wildStrings 0 MediumFuzzy  fuzzyPattern `shouldBe` [Match (last wildStrings) "Myrmecophaga" 2]
+      findMatchesFuzzy wildStrings 0 MediumFuzzy  fuzzyPattern `shouldBe` [Match (last wildStrings) "Myrmecophaga" 38 2]
     
     it "should handle deletion of characters" $ do
       let fuzzyPattern = "Pkas"
@@ -124,7 +124,7 @@ spec = do
           Edit: replace 'i' with 'P' => Pkas (1 edit)
           Match
       -}
-      findMatchesFuzzy wildStrings 0 LowFuzzy fuzzyPattern `shouldContain` [Match (wildStrings !! 1) "ikas" 1]
+      findMatchesFuzzy wildStrings 0 LowFuzzy fuzzyPattern `shouldContain` [Match (wildStrings !! 1) "ikas" 1 1]
 
     it "should be able to fuzzy search bigger text files" $ do
       f <- readFile "test/random_text.txt"


### PR DESCRIPTION
- Adds formatting to the console output
- Enables calling regex and fuzzy implementations of the `findMatch*` functions
- Does not handle context yet