### PR TITLE
Added ability to display context

### DIFF
--- a/src/CmdParser.hs
+++ b/src/CmdParser.hs
@@ -36,11 +36,9 @@ recursive = switch ( long "recursive"
   <> help "Recursively search subdirectories")
 
 numlines :: Parser Bool
-numlines = option auto
+numlines = switch
   (  long "line-numbers"
    <> short 'n'
-   <> metavar "Bool"
-   <> value False
    <> help "Print the line numbers of each match: True, [False]" )
 
 opts :: Parser Opts

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -11,41 +11,71 @@ import CmdParser(Command(..), Opts(..), Args(..), appInfo)
 someFunc :: IO ()
 someFunc = run =<< execParser CmdParser.appInfo
 
--- | Represents a file match with the path of the file and the matches
-data FileMatch = FileMatch String [Match]
+{-
+  @brief Represents the matches for a given file,
+    with the filepath, the list of matches for the file,
+    as well as the contents of the file.
+-}
+data FileMatch = FileMatch String [Match] [String]
 
 instance Show FileMatch where
-  show (FileMatch name matches) = name ++ ":\n" ++ foldr (\x y -> ("\t" ++ show x ++ "\n") ++ y) "" matches
+  show (FileMatch name matches _) = name ++ ":\n" ++ foldr (\x y -> ("\t" ++ show x ++ "\n") ++ y) "" matches
 
 run :: Command -> IO ()
 run (Command (Opts c fz r lns) (Args p fs)) = do
   files <- sequence (map (`File.dispatchFileExtraction` r) fs)
   let patt = p
-      fileMatches = filter (\(FileMatch path matches) -> not (null matches))
+      fileMatches = filter (\(FileMatch _ matches _) -> not (null matches))
         (map (\x -> exFileToMatch x (toFuzzy fz) patt) (concat files))
-  mapM_ (\x -> printFileMatch x lns) fileMatches
+  mapM_ (\x -> printFileMatch x lns c) fileMatches
 
 -- | Creates a FileMatch from the file, fuzziness of the query, and the string pattern.
 exFileToMatch :: ExFile -> Fuzziness -> String -> FileMatch
 exFileToMatch (ExFile filepath contents) fz pattern = do
   let matches = dispatchMatching contents 0 fz pattern
-  FileMatch filepath matches
+  FileMatch filepath matches contents
 
 -- | properly formats the console output for a FileMatch.
-
-printFileMatch :: FileMatch -> Bool -> IO ()
-printFileMatch (FileMatch filepath matches) linenumbers = do
+printFileMatch :: FileMatch -> Bool -> Int -> IO ()
+printFileMatch (FileMatch filepath matches content) lns numContextLines = do
+  let contextLines = fetchContext content numContextLines
+      divider = getDivider content numContextLines
   setSGR [SetColor Foreground Vivid Blue]
-  putStr (filepath ++ ":\n")
-  if linenumbers
-    then mapM_ printMatchLines matches
-    else mapM_ printMatch matches
-  putStr "\n"
+  putStr (filepath ++ " (" ++ show (length matches) ++ " matches):\n")
+  setSGR [SetColor Foreground Vivid White]
+  putStrLn divider
+  mapM_ (\x -> printMatch x lns contextLines divider) matches
+  putStrLn ""
 
 -- | Porperly formats the console output for a Match.
-printMatch :: Match -> IO ()
-printMatch m = do
-  let (f,s,t,_) = getLineParts m
+printMatch :: Match -> Bool -> (Int -> ([(String,Int)],[(String,Int)])) -> String -> IO ()
+printMatch (Match line matchedPattern matchIdx lineNum) lns contextGetter divider = do
+  let matchParts = getLineParts (Match line matchedPattern matchIdx lineNum)
+      (trailing,leading) = contextGetter lineNum
+  mapM_ (\(ln,idx) -> printLine (ln,"","") lns idx) trailing
+  printLine matchParts lns lineNum
+  mapM_ (\(ln,idx) -> printLine (ln,"","") lns idx) leading
+  putStr divider 
+
+printLine :: (String,String,String) -> Bool -> Int -> IO ()
+printLine (f,s,t) lns lineNum = if lns 
+  then printLineWithNum (f,s,t) lineNum
+  else printLineNoNum (f,s,t)
+  
+
+printLineWithNum :: (String,String,String) -> Int -> IO ()
+printLineWithNum (f,s,t) lineNum = do
+  setSGR[SetColor Foreground Vivid Green]
+  putStr (show (lineNum+1) ++ ":\t")
+  setSGR [SetColor Foreground Vivid White]
+  putStr f
+  setSGR [SetColor Foreground Vivid Red]
+  putStr s
+  setSGR [SetColor Foreground Vivid White]
+  putStrLn t
+
+printLineNoNum :: (String,String,String) -> IO ()
+printLineNoNum (f,s,t) = do
   setSGR [SetColor Foreground Vivid White]
   putStr ("\t" ++ f)
   setSGR [SetColor Foreground Vivid Red]
@@ -53,18 +83,11 @@ printMatch m = do
   setSGR [SetColor Foreground Vivid White]
   putStrLn t
 
--- | Porperly formats the console output for a Match with line numbers
-printMatchLines :: Match -> IO ()
-printMatchLines m = do
-  let (f,s,t,l) = getLineParts m
-  setSGR [SetColor Foreground Vivid Green]
-  putStr ("\t" ++ (show (l+1)) ++ ":") -- +1 because of 0 indexing to 1
-  setSGR [SetColor Foreground Vivid White]
-  putStr f
-  setSGR [SetColor Foreground Vivid Red]
-  putStr s
-  setSGR [SetColor Foreground Vivid White]
-  putStrLn t
+getDivider :: [String] -> Int -> String
+getDivider _ 0 = []
+getDivider lines _ = do 
+  let maxLineLength = foldr (max . length) 0 lines
+  ([1..(min maxLineLength 75)] >> "=") ++ "\n"
 
 -- | Converts the given parameter to fuzziness level.
 toFuzzy :: [Char] -> Fuzziness
@@ -73,4 +96,17 @@ toFuzzy "LOW" = LowFuzzy
 toFuzzy "MED" = MediumFuzzy 
 toFuzzy "HIGH" = HighFuzzy 
 toFuzzy err = error (err ++ " is not one of: \"NONE\", \"LOW\", \"MED\", \"HIGH\"")
+
+{-
+  @brief Creates a tuple containing the trailing and leading context lines.
+-}
+fetchContext :: [String] -> Int -> Int -> ([(String,Int)], [(String,Int)])
+fetchContext _ 0 _ = ([],[])
+fetchContext content numLines matchIdx = (trailing content matchIdx, leading content matchIdx)
+  where trailing content matchIdx = zip (drop trailingStartIdx (take trailingEndIdx content)) [trailingStartIdx .. trailingEndIdx]
+        leading content matchIdx = zip (drop leadingStartIdx (take leadingEndIdx content)) [leadingStartIdx .. leadingEndIdx]
+        trailingStartIdx = max 0 (matchIdx - numLines)
+        trailingEndIdx = matchIdx
+        leadingStartIdx = matchIdx + 1
+        leadingEndIdx = min (matchIdx + numLines + 1) (length content)
 

--- a/src/Matching.hs
+++ b/src/Matching.hs
@@ -45,8 +45,8 @@ instance Show Fuzziness where
   show MediumFuzzy = "Fuzzy: Med(" ++ show (editDistance MediumFuzzy) ++ ")"
   show HighFuzzy = "Fuzzy: High(" ++ show (editDistance HighFuzzy) ++ ")"
 
-getLineParts :: Match -> (String, String, String, Int)
-getLineParts (Match line matchedPattern idx ln) = (take idx line, matchedPattern, drop (idx + length matchedPattern) line, ln)
+getLineParts :: Match -> (String, String, String)
+getLineParts (Match line matchedPattern idx _) = (take idx line, matchedPattern, drop (idx + length matchedPattern) line)
 
 -- | Dispatches the correct matching function according to the specified fuzzy level
 dispatchMatching :: [String] -> Int -> Fuzziness -> String -> [Match]


### PR DESCRIPTION
Context and line numbers:
<img width="852" alt="Screen Shot 2021-02-27 at 12 23 26 AM" src="https://user-images.githubusercontent.com/40721169/109381912-033fc000-7892-11eb-8a66-cd0fed361e16.png">

Context no line numbers:
<img width="964" alt="Screen Shot 2021-02-27 at 12 23 49 AM" src="https://user-images.githubusercontent.com/40721169/109381920-118ddc00-7892-11eb-8df0-c1a66a2828d3.png">

Line numbers no context:
<img width="791" alt="Screen Shot 2021-02-27 at 12 24 06 AM" src="https://user-images.githubusercontent.com/40721169/109381929-1bafda80-7892-11eb-8daa-235c5b031f42.png">

No line numbers, no context:
<img width="628" alt="Screen Shot 2021-02-27 at 12 25 16 AM" src="https://user-images.githubusercontent.com/40721169/109381962-4732c500-7892-11eb-80ea-5ca7466572b8.png">


I moved the line numbers to the edge of the screen to make it a little easier to read.

I put dividers between matches when using the context mode
